### PR TITLE
Make feather compatible with newer version of ghosts

### DIFF
--- a/source/actions/index.js
+++ b/source/actions/index.js
@@ -14,7 +14,6 @@ export function fetchHomeContents() {
   }));
   const initialPosts = axios.get(ghost.url.api('posts', {
     include: 'tags',
-    fields: 'id,title,slug,image,feature_image,tags,html',
     limit: 5
   }));
   return (dispatch) => {


### PR DESCRIPTION
Newer version throws a 500 error, if we try to restrict fields but want to include tags as well.
InternalServerError: ER_BAD_FIELD_ERROR: Unknown column 'tags' in 'field list'

Ommiting field param, till it is fixed.